### PR TITLE
fix: RHEL compatibility for systemd service ordering

### DIFF
--- a/ZBProxy.service
+++ b/ZBProxy.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=ZBProxy Service
 Documentation=https://github.com/layou233/ZBProxy
-After=network.target nss-lookup.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
On RHEL-based Linux distros, `nss-lookup.target` is deprecated and remains `inactive (dead)` forever by default.
```console
$ systemctl status nss-lookup.target
○ nss-lookup.target - Host and Network Name Lookups
     Loaded: loaded (/usr/lib/systemd/system/nss-lookup.target; static)
     Active: inactive (dead)
       Docs: man:systemd.special(7)
```
This pull request replaces its usage in the service file with `network-online.target`, which is reached when the network is "up", and is also available on Debian-based distros. More information can be found at [https://systemd.io/NETWORK_ONLINE/](https://systemd.io/NETWORK_ONLINE/).